### PR TITLE
Support https endpoint

### DIFF
--- a/lib/fluent/plugin/out_http_buffered.rb
+++ b/lib/fluent/plugin/out_http_buffered.rb
@@ -43,6 +43,7 @@ module Fluent
       @statuses = [] if @statuses.nil?
 
       @http = Net::HTTP.new(@uri.host, @uri.port)
+      @http.use_ssl = (@uri.scheme == "https")
       @http.read_timeout = @http_read_timeout
       @http.open_timeout = @http_open_timeout
     end


### PR DESCRIPTION
Posting to urls which start with https:// failed with an error. Let's support https.
