### PR TITLE
send_only_records as config parameter

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -33,6 +33,8 @@ The plugin was influenced by the standard http_output_plugin[https://github.com/
       http_read_timeout 2.2
       #Open timeout in seconds, supports floats
       http_open_timeout 2.34
+      # Send only record instead of [tag,time,record]
+      send_only_records true
     </match>
 
 == Copyright

--- a/lib/fluent/plugin/out_http_buffered.rb
+++ b/lib/fluent/plugin/out_http_buffered.rb
@@ -23,6 +23,9 @@ module Fluent
     # open timeout for the http call
     config_param :http_open_timeout, :float, default: 2.0
 
+    # discard tag and time from data
+    config_param :send_only_records, :bool, default: false
+
     def configure(conf)
       super
 
@@ -66,7 +69,11 @@ module Fluent
     def write(chunk)
       data = []
       chunk.msgpack_each do |(tag, time, record)|
-        data << [tag, time, record]
+        if @send_only_records
+          data << record
+	else
+          data << [tag, time, record]
+        end
       end
 
       request = create_request(data)

--- a/test/fluent/plugin/test_out_http_buffered.rb
+++ b/test/fluent/plugin/test_out_http_buffered.rb
@@ -30,6 +30,7 @@ class HttpBufferedOutputTest < Test::Unit::TestCase
     assert_equal [], d.instance.instance_eval { @statuses }
     assert_equal 2.0, d.instance.instance_eval { @http_read_timeout }
     assert_equal 2.0, d.instance.instance_eval { @http_open_timeout }
+    assert_equal false, d.instance.instance_eval { @send_only_records }
   end
 
   def test_invalid_endpoint


### PR DESCRIPTION
Hi,

I had some difficulties using this plugin to collect metrics into Blueflood, so, I had to modify the plugin and add a new config_param that seems to be a good feature to add to the project.

Basically, Blueflood is waiting for a list of records, but http_buffered sends _**[[tag,time,record]]**_, which was a problem.

To solve that, I add a new config_param, **_send_only_records_**, that can be enabled to send only an array of records.

Thanks.
